### PR TITLE
os+redis: remove docker volumes on cleanup

### DIFF
--- a/hseb/engine/redis.py
+++ b/hseb/engine/redis.py
@@ -84,8 +84,10 @@ class RedisEngine(EngineBase):
             self.client.close()
         if self.container:
             self.container.stop()
-        if cleanup:
+        if cleanup and self.container:
             self.container.remove()
+            if self.container.client:
+                self.container.client.prune_volumes()
 
     def commit(self):
         pass


### PR DESCRIPTION
as indexes might take a ton of space on the benchmark node.