### PR TITLE
Exclude source as its not necessary

### DIFF
--- a/hseb/engine/elastic.py
+++ b/hseb/engine/elastic.py
@@ -124,7 +124,7 @@ class ElasticsearchEngine(EngineBase):
         if search_params.filter_selectivity != 100:
             es_query["filter"] = {"terms": {"tag": [search_params.filter_selectivity]}}
         start = time.time_ns()
-        response = self.client.search(index="test", knn=es_query, source=["_id"], size=top_k)
+        response = self.client.search(index="test", knn=es_query, source=False, size=top_k)
         end = time.time_ns()
         return SearchResponse(
             results=[DocScore(doc=int(doc["_id"]), score=doc["_score"]) for doc in response["hits"]["hits"]],


### PR DESCRIPTION
Until ES 9.2, vectors were still included in _source. When requesting a particular field in _source, that value is loaded and retrieved, which can cost a bit. 

Since no fields are actually necessary (just id and score), this makes it plain that we don't need to fetch anything